### PR TITLE
feat #4: add POST /api/documents/upload endpoint with PDF/DOCX validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fastapi uvicorn httpx pytest pytest-cov
+          pip install fastapi uvicorn httpx pytest pytest-cov python-multipart
 
       - name: Run all tests with coverage
         run: |

--- a/api/main.py
+++ b/api/main.py
@@ -20,11 +20,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from datetime import date
 from typing import List, Optional
 
-from fastapi import FastAPI, HTTPException, status, Query
+from fastapi import FastAPI, HTTPException, status, Query, UploadFile, File, Form
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, field_validator
+import uuid
 
 from factories.repository_factory import RepositoryFactory, STORAGE_MEMORY
+from src.document import Document, DocumentStatus, ALLOWED_FILE_TYPES, MAX_FILE_SIZE_MB
 from services.user_service import (
     UserService, UserNotFoundError, DuplicateEmailError,
     InvalidRoleError, UserNotActiveError,
@@ -56,6 +58,7 @@ app = FastAPI(
 _user_repo = RepositoryFactory.get_user_repository(STORAGE_MEMORY)
 _project_repo = RepositoryFactory.get_project_repository(STORAGE_MEMORY)
 _task_repo = RepositoryFactory.get_task_repository(STORAGE_MEMORY)
+_document_repo = RepositoryFactory.get_document_repository(STORAGE_MEMORY)
 
 user_service = UserService(_user_repo)
 project_service = ProjectService(_project_repo, _user_repo)
@@ -711,6 +714,80 @@ def delete_task(task_id: str, requestor_id: str = Query(...)):
         raise HTTPException(status_code=403, detail=str(e))
     except TaskStateError as e:
         raise HTTPException(status_code=422, detail=str(e))
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Documents  (US-004)
+# ════════════════════════════════════════════════════════════════════════════
+
+@app.post(
+    "/api/documents/upload",
+    tags=["Documents"],
+    summary="Upload a research document",
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: {"description": "Invalid file type or file too large"},
+        404: {"description": "Uploader user not found"},
+    },
+)
+def upload_document(
+    title: str = Form(..., description="Document title"),
+    uploader_id: str = Form(..., description="ID of the user uploading the document"),
+    file: UploadFile = File(..., description="PDF or DOCX file (max 50 MB)"),
+):
+    """
+    Upload a research document (PDF or DOCX, max 50 MB).
+
+    Validates file type and size before storing. Closes issue #4.
+    """
+    # Resolve uploader
+    try:
+        uploader = user_service.get_user(uploader_id)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # Determine extension from filename
+    filename = file.filename or ""
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext not in ALLOWED_FILE_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type '.{ext}'. Allowed: {sorted(ALLOWED_FILE_TYPES)}",
+        )
+
+    # Read content to determine actual size
+    content = file.file.read()
+    size_mb = len(content) / (1024 * 1024)
+    if size_mb > MAX_FILE_SIZE_MB:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File size {size_mb:.2f} MB exceeds the {MAX_FILE_SIZE_MB} MB limit.",
+        )
+
+    # Build and upload domain object
+    doc_id = str(uuid.uuid4())
+    doc = Document(document_id=doc_id, title=title, uploaded_by=uploader)
+    doc.upload(
+        file_path=f"uploads/{doc_id}/{filename}",
+        file_type=ext,
+        file_size_mb=round(size_mb, 4),
+        version_id=str(uuid.uuid4()),
+    )
+
+    if doc.status == DocumentStatus.REJECTED:
+        raise HTTPException(status_code=400, detail="Document validation failed.")
+
+    _document_repo.save(doc)
+
+    return {
+        "document_id": doc_id,
+        "title": title,
+        "file_name": filename,
+        "file_type": ext,
+        "file_size_mb": round(size_mb, 4),
+        "status": doc.status.value,
+        "uploader_id": uploader_id,
+    }
 
 
 # ── Health check ──────────────────────────────────────────────────────────────

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.23.0
 httpx>=0.24.0
 pytest>=9.0.0
 pytest-cov>=7.0.0
+python-multipart>=0.0.9


### PR DESCRIPTION
Closes #4

Adds POST /api/documents/upload to address US-004 (Upload Research Document).

What this PR does

Adds a new endpoint that accepts a multipart file upload with title and uploader_id form fields. It validates the file extension (PDF or DOCX only), checks file size does not exceed 50 MB, creates a Document domain object and calls the existing upload/validate/store lifecycle, saves the validated document to the in-memory DocumentRepository, and returns document metadata including document_id, title, file_type, file_size_mb, and status.

Acceptance criteria met

File types allowed: PDF, DOCX — enforced with 400 response for other types

File is validated — uses existing Document.validate() from domain model

File is uploaded successfully — returns 201 with document metadata

Files changed

api/main.py — added UploadFile/Form imports, document repo wiring, and the upload endpoint (+78 lines)